### PR TITLE
feat: add consumable quantity

### DIFF
--- a/assets/theme/theme-base/components/input/_inputnumber.scss
+++ b/assets/theme/theme-base/components/input/_inputnumber.scss
@@ -67,6 +67,7 @@
 .p-inputnumber-buttons-horizontal .p-inputnumber-input {
     order: 2;
     border-radius: 0;
+    min-width: 0;
 }
 
 .p-inputnumber-buttons-horizontal .p-button.p-inputnumber-button-down {

--- a/components/ConsumableDataTable.vue
+++ b/components/ConsumableDataTable.vue
@@ -14,7 +14,17 @@
             class="text-right white-space-nowrap"
         >
             <template #body="{ data }">
-                {{ data.weight ? formatWeight(data.weight) : '-' }}
+                <div class="flex flex-column gap-1 lg:gap-2">
+                    <div>
+                        {{ data.weight ? formatWeight(data.weight) : '-' }}
+                    </div>
+                    <div
+                        v-if="data.quantity && data.quantity > 1"
+                        class="text-color-light"
+                    >
+                        x {{ data.quantity }}
+                    </div>
+                </div>
             </template>
         </PrimeColumn>
 

--- a/components/GearQuantityEditorDialog.vue
+++ b/components/GearQuantityEditorDialog.vue
@@ -1,6 +1,7 @@
 <template>
     <PrimeDialog
         modal
+        class="w-full mx-2 max-w-20rem"
         :visible="isOpen"
         :header="$t('ACTION_EDIT_QUANTITY')"
         @update:visible="(value: boolean) => !value && onCancel()"

--- a/components/trip/TripConsumableSection.vue
+++ b/components/trip/TripConsumableSection.vue
@@ -53,7 +53,7 @@ const displayConsumableCatergories = computed(() =>
 
 const consumableWeightByCategory = computed(() =>
     _mapValues(consumablesByCategory.value, (consumables) =>
-        _sumBy(consumables, (consumable) => +consumable.weight || 0),
+        _sumBy(consumables, dataUtils.getConsumableWeight),
     ),
 );
 </script>

--- a/components/trip/TripWeightInfo.vue
+++ b/components/trip/TripWeightInfo.vue
@@ -72,7 +72,7 @@ const consumablesByCategory = computed(() =>
 );
 const consumableWeightByCategory = computed(() =>
     _mapValues(consumablesByCategory.value, (consumables) =>
-        _sumBy(consumables, (consumable) => +consumable.weight || 0),
+        _sumBy(consumables, dataUtils.getConsumableWeight),
     ),
 );
 const consumablesWeightItems = computed<WeightBarChartSubItem[]>(() =>
@@ -83,7 +83,9 @@ const consumablesWeightItems = computed<WeightBarChartSubItem[]>(() =>
         }))
         .sort((a, b) => b.weight - a.weight),
 );
-const consumablesWeight = computed(() => _sumBy(props.consumables, 'weight'));
+const consumablesWeight = computed(() =>
+    _sumBy(props.consumables, dataUtils.getConsumableWeight),
+);
 
 // gears
 const gearsByCategory = computed(() =>

--- a/functions/src/utils/trip-publish-unpublish.ts
+++ b/functions/src/utils/trip-publish-unpublish.ts
@@ -87,7 +87,7 @@ export const publishTrip = async (tripId: string) => {
     );
     const consumablesWeight = _.sumBy(
         _.values(trip.consumables),
-        (consumable) => +consumable.weight || 0,
+        (consumable) => +consumable.weight * (consumable?.quantity || 1) || 0,
     );
     const packWeight = baseWeight + consumablesWeight;
     const wornWeight = Object.values(tripShareWornGears).reduce(

--- a/functions/types/types.d.ts
+++ b/functions/types/types.d.ts
@@ -139,6 +139,7 @@ export type Consumable = {
     name: string;
     weight: number; // grams
     category: ConsumableCategory;
+    quantity?: number;
 };
 export type EditingConsumable = Partial<Consumable>;
 

--- a/pages/trip-share/[id].vue
+++ b/pages/trip-share/[id].vue
@@ -156,7 +156,7 @@ const gearsWeight = _sumBy(
 );
 const consumablesWeight = _sumBy(
     consumablesInTrip,
-    (consumable) => +consumable.weight || 0,
+    dataUtils.getConsumableWeight,
 );
 const wornGearsWeight = _sumBy(
     wornGearsInTrip,

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -150,6 +150,7 @@ declare global {
         name: string;
         weight: number; // grams
         category: ConsumableCategory;
+        quantity?: number;
     };
     type EditingConsumable = Partial<Consumable>;
 

--- a/utils/data-utils.ts
+++ b/utils/data-utils.ts
@@ -16,6 +16,9 @@ const groupConsumablesByCategory = <T extends Consumable>(
             : 'others',
     );
 
+const getConsumableWeight = (consumable: Consumable): number =>
+    +consumable.weight * (consumable?.quantity || 1) || 0;
+
 const getTripGearsWeight = (
     trip: Trip,
     gearMap: Record<string, Gear>,
@@ -41,7 +44,7 @@ const getTripWornGearsWeight = (
     );
 
 const getTripConsumablessWeight = (trip: Trip): number =>
-    _sum(_map(trip.consumables || [], (consumable) => +consumable.weight || 0));
+    _sum(_map(trip.consumables || [], getConsumableWeight));
 
 const getTripBaseWeight = (trip: Trip, gearMap: Record<string, Gear>): number =>
     getTripGearsWeight(trip, gearMap) + getTripConsumablessWeight(trip);
@@ -300,6 +303,7 @@ const convertedEditingGearToTempGear = (editingGear: EditingGear): Gear => {
 export default {
     groupGearsByCategory,
     groupConsumablesByCategory,
+    getConsumableWeight,
     getTripGearsWeight,
     getTripWornGearsWeight,
     getTripConsumablessWeight,


### PR DESCRIPTION
This pull request introduces enhancements to the handling of consumables across multiple components and utilities. The changes primarily focus on adding support for consumable quantities, improving weight calculations, and refining the user interface for consumable-related dialogs. Below are the most important changes grouped by theme:

### Enhancements to Consumable Quantity Handling:
* [`components/ConsumableEditorDialog.vue`](diffhunk://#diff-657bfe73f6070828cd17c22fbc22d524d1ea0d52c560c8ab97cd53613bc6d784R55-R75): Added a new `quantity` field to the consumable editor form, including validation rules and default state initialization. Updated the `onSubmit` method to include `quantity` in the consumable data if provided. [[1]](diffhunk://#diff-657bfe73f6070828cd17c22fbc22d524d1ea0d52c560c8ab97cd53613bc6d784R55-R75) [[2]](diffhunk://#diff-657bfe73f6070828cd17c22fbc22d524d1ea0d52c560c8ab97cd53613bc6d784R167-R173) [[3]](diffhunk://#diff-657bfe73f6070828cd17c22fbc22d524d1ea0d52c560c8ab97cd53613bc6d784R186-R189) [[4]](diffhunk://#diff-657bfe73f6070828cd17c22fbc22d524d1ea0d52c560c8ab97cd53613bc6d784L184-R225)
* [`functions/src/utils/trip-publish-unpublish.ts`](diffhunk://#diff-73c589b24f97504f74b6bcca59f456549ec9a26af04d8b64c5120a0484da7141L90-R90): Updated weight calculation to account for the `quantity` of consumables.
* [`utils/data-utils.ts`](diffhunk://#diff-442a995a95fa3d55211129bc8bef5e23c1841a8c3ce2e6ebd654ae5523d25295R19-R21): Added a new utility function `getConsumableWeight` to calculate the total weight of a consumable based on its `weight` and `quantity`. Refactored related methods to use this utility. [[1]](diffhunk://#diff-442a995a95fa3d55211129bc8bef5e23c1841a8c3ce2e6ebd654ae5523d25295R19-R21) [[2]](diffhunk://#diff-442a995a95fa3d55211129bc8bef5e23c1841a8c3ce2e6ebd654ae5523d25295L44-R47) [[3]](diffhunk://#diff-442a995a95fa3d55211129bc8bef5e23c1841a8c3ce2e6ebd654ae5523d25295R306)

### UI Improvements for Consumable Management:
* [`components/ConsumableDataTable.vue`](diffhunk://#diff-9e18173f51008e3d1edfb3458970b6f4513ae0a7d803297c2ccfdf7bff7f79ccR17-R27): Enhanced the display of consumables in the data table to show `quantity` when greater than 1, along with the weight.
* [`components/GearQuantityEditorDialog.vue`](diffhunk://#diff-e810442484ef9ee1db6bafb9d9f73c8a30419cbebf3153d900a511c26cb468f6R4): Adjusted the dialog width for better responsiveness.

### Refactoring Weight Calculations:
* `components/trip/TripConsumableSection.vue` and `components/trip/TripWeightInfo.vue`: Replaced inline weight calculation logic with the new `getConsumableWeight` utility for consistency and maintainability. [[1]](diffhunk://#diff-f9a1e4186441c54f488a530a895931e0a9a13dffdfbecfadae0287d126cf03bcL56-R56) [[2]](diffhunk://#diff-767f8a566feaf152f4810f0d6eeea2a958f90ddba782b20e3022ddc9690cb4c7L75-R75) [[3]](diffhunk://#diff-767f8a566feaf152f4810f0d6eeea2a958f90ddba782b20e3022ddc9690cb4c7L86-R88)
* `pages/trip-share/[id].vue`: Updated consumable weight calculations to use the `getConsumableWeight` utility. ([pages/trip-share/[id].vueL159-R159](diffhunk://#diff-6bf33c97a426ea0cacf81e5ebcbbc57ac2a57145ce3afd2bcf682bb98ffaac3dL159-R159)) 

### Minor Styling Adjustment:
* [`assets/theme/theme-base/components/input/_inputnumber.scss`](diffhunk://#diff-cced32e11b9f07267834ee5efb7377887d378735e29bf021027baf681d4b4a16R70): Added `min-width: 0` to ensure proper layout of input number elements.