### PR TITLE
feat: gear weight tree map

### DIFF
--- a/components/TripWeightTreeMap.vue
+++ b/components/TripWeightTreeMap.vue
@@ -1,0 +1,184 @@
+<template>
+    <div
+        ref="container"
+        class="border-round-lg overflow-hidden"
+        :style="{ aspectRatio: props.ratio }"
+    >
+        <WeightTreeMap
+            v-if="isMounted"
+            :items="backpackWeightItems"
+            :width="width"
+            :height="height"
+            :class="['trip-weight-tree-map', 'bg-white']"
+        >
+            <template #node="{ item }">
+                <div
+                    :class="[
+                        'absolute top-0 left-0 w-full h-full',
+                        'border-1 border-solid border-white overflow-hidden',
+                    ]"
+                >
+                    <!-- img -->
+                    <img
+                        v-if="item.data && getGearPhotoUrl(item.data, 'sm')"
+                        :src="getGearPhotoUrl(item.data, 'sm')"
+                        :alt="item.data.name"
+                        :class="[
+                            'trip-weight-tree-map__gear-photo',
+                            'cursor-pointer',
+                        ]"
+                        role="button"
+                        @click="openGearCardDialog(item.data)"
+                    />
+                    <!-- category avatar -->
+                    <div
+                        v-else
+                        class="flex absolute top-0 left-0 w-full h-full justify-content-center align-items-center"
+                    >
+                        <GearCategoryAvatar
+                            :category="item.data.category"
+                            size="small"
+                            :style="{ backgroundColor: item.color }"
+                        />
+                    </div>
+                    <!-- label -->
+                    <!-- <div
+                      :class="[
+                          'text-xs absolute bottom-0 right-0 w-full bg-white p-1',
+                          'flex justify-content-between align-items-center gap-1',
+                          'overflow-hidden',
+                      ]"
+                  >
+                      <div class="text-ellipsis">{{ item.label }}</div>
+                      <div class="white-space-nowrap">
+                          {{ formatWeight(item.weight) }}
+                      </div>
+                  </div> -->
+                </div>
+            </template>
+        </WeightTreeMap>
+    </div>
+</template>
+
+<script lang="ts" setup>
+const props = defineProps<{
+    gears: GearWithQuantity[];
+    wornGears: GearWithQuantity[];
+    consumables: Consumable[];
+    ratio: number;
+}>();
+const { gears, wornGears, consumables } = toRefs(props);
+const container = ref<HTMLElement | null>(null);
+const width = ref(0);
+const height = ref(0);
+const isMounted = ref(false);
+const updateDimensions = () => {
+    if (!container.value) return;
+    width.value = container.value.offsetWidth;
+    height.value = width.value / props.ratio;
+};
+onMounted(() => {
+    if (!container.value) return;
+    updateDimensions();
+    window.addEventListener('resize', updateDimensions);
+    isMounted.value = true;
+});
+onBeforeUnmount(() => {
+    window.removeEventListener('resize', updateDimensions);
+});
+
+const { gearsByCategory, gearWeightByCategory } = useTripWeightData({
+    gearsRef: gears,
+    wornGearsRef: wornGears,
+    consumablesRef: consumables,
+});
+const i18n = useI18n();
+const { formatWeight } = useLangUtils();
+const { openGearCardDialog } = useGearCardDialog();
+const { getGearPhotoUrl } = dataUtils;
+const { gearCategoryToLabel, consumableCategoryToLabel } = useLangUtils();
+
+// const consumablesWeightItems = computed<WeightTreeMapItem[]>(() =>
+//     _orderBy(
+//         Object.entries(consumableWeightByCategory.value).map(
+//             ([category, weight]) => ({
+//                 label: consumableCategoryToLabel(
+//                     category as ConsumableCategory,
+//                 ),
+//                 weight,
+//                 value: weight,
+//                 color: constants.COLORS.CONSUMABLES_WEIGHT,
+//                 children: _orderBy(
+//                     consumablesByCategory.value[
+//                         category as ConsumableCategory
+//                     ]?.map((consumable) => ({
+//                         label: consumable.name,
+//                         weight: consumable.weight,
+//                         value: consumable.weight,
+//                         color: constants.COLORS.CONSUMABLES_WEIGHT,
+//                     })),
+//                     'value',
+//                     'desc',
+//                 ),
+//             }),
+//         ),
+//         'value',
+//         'desc',
+//     ),
+// );
+const backpackWeightItems = computed<WeightTreeMapItem<Gear>[]>(() =>
+    _slice(
+        _orderBy(
+            [
+                ...Object.entries(gearWeightByCategory.value).map(
+                    ([category, weight]) => ({
+                        label: gearCategoryToLabel(category as GearCategory),
+                        weight,
+                        value: weight,
+                        color: constants.GEAR_CATEGORIES[
+                            category as GearCategory
+                        ].color,
+                        children:
+                            _orderBy(
+                                gearsByCategory.value[category as GearCategory]
+                                    ?.filter((gear) =>
+                                        dataUtils.getGearPhotoUrl(gear),
+                                    )
+                                    .map((gear) => ({
+                                        label: gear.name,
+                                        weight: gear.weight,
+                                        value: gear.weight,
+                                        data: gear,
+                                        color: constants.GEAR_CATEGORIES[
+                                            category as GearCategory
+                                        ].color,
+                                    })),
+                                'value',
+                                'desc',
+                            ) || [],
+                    }),
+                ),
+                // ...consumablesWeightItems.value,
+            ],
+            'value',
+            'desc',
+        ),
+        0,
+        10,
+    ),
+);
+</script>
+
+<style lang="scss">
+.trip-weight-tree-map {
+    &__gear-photo {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        transition: transform 0.1s ease-out;
+        &:hover {
+            transform: scale(1.1);
+        }
+    }
+}
+</style>

--- a/components/WeightTreeMap.vue
+++ b/components/WeightTreeMap.vue
@@ -1,0 +1,53 @@
+<template>
+    <div
+        class="relative"
+        :style="{ width: `${props.width}px`, height: `${props.height}px` }"
+    >
+        <div
+            v-for="(item, index) in treeMapItems"
+            :key="index"
+            class="absolute"
+            :style="{
+                left: `${item.x0}px`,
+                top: `${item.y0}px`,
+                width: `${item.x1 - item.x0}px`,
+                height: `${item.y1 - item.y0}px`,
+            }"
+        >
+            <slot name="node" :item="item"></slot>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import squarify from 'squarify';
+
+type TreeMapItem = {
+    x0: number;
+    y0: number;
+    x1: number;
+    y1: number;
+    value: number;
+    normalizedValue: number;
+} & WeightTreeMapItem<any>;
+
+const props = defineProps<{
+    items: WeightTreeMapItem<any>[];
+    width: number;
+    height: number;
+}>();
+const treeMapItems = ref<TreeMapItem[]>([]);
+const updateTreeMapItems = () => {
+    const container = { x0: 0, y0: 0, x1: props.width, y1: props.height };
+    treeMapItems.value = squarify(props.items, container);
+};
+
+onMounted(updateTreeMapItems);
+// watch items, width, and height to update treeMapItems
+watch(
+    [() => props.items, () => props.width, () => props.height],
+    updateTreeMapItems,
+);
+</script>
+
+<style></style>

--- a/components/trip/TripWeightInfo.vue
+++ b/components/trip/TripWeightInfo.vue
@@ -62,19 +62,23 @@ const props = defineProps<{
     wornGears: GearWithQuantity[];
     consumables: Consumable[];
 }>();
+const { gears, wornGears, consumables } = toRefs(props);
+const {
+    gearsWeight,
+    gearWeightByCategory,
+    consumablesWeight,
+    consumableWeightByCategory,
+    backpackWeight,
+    wornGearsWeight,
+} = useTripWeightData({
+    gearsRef: gears,
+    wornGearsRef: wornGears,
+    consumablesRef: consumables,
+});
 const i18n = useI18n();
 const { formatWeight, gearCategoryToLabel, consumableCategoryToLabel } =
     useLangUtils();
 
-// consumables
-const consumablesByCategory = computed(() =>
-    dataUtils.groupConsumablesByCategory(props.consumables),
-);
-const consumableWeightByCategory = computed(() =>
-    _mapValues(consumablesByCategory.value, (consumables) =>
-        _sumBy(consumables, dataUtils.getConsumableWeight),
-    ),
-);
 const consumablesWeightItems = computed<WeightBarChartSubItem[]>(() =>
     Object.entries(consumableWeightByCategory.value)
         .map(([category, weight]) => ({
@@ -82,27 +86,6 @@ const consumablesWeightItems = computed<WeightBarChartSubItem[]>(() =>
             weight,
         }))
         .sort((a, b) => b.weight - a.weight),
-);
-const consumablesWeight = computed(() =>
-    _sumBy(props.consumables, dataUtils.getConsumableWeight),
-);
-
-// gears
-const gearsByCategory = computed(() =>
-    dataUtils.groupGearsByCategory(props.gears),
-);
-const gearWeightByCategory = computed(() =>
-    _mapValues(gearsByCategory.value, (gears) =>
-        _sumBy(gears, (gear) => (+gear.weight || 0) * gear.quantity),
-    ),
-);
-const gearsWeight = computed(() =>
-    _sumBy(props.gears, (gear) => (+gear.weight || 0) * gear.quantity),
-);
-
-// backpack weight
-const backpackWeight = computed(
-    () => gearsWeight.value + consumablesWeight.value,
 );
 const backpackWeightItems = computed<WeightBarChartItem[]>(() => [
     ...Object.entries(gearWeightByCategory.value).map(([category, weight]) => ({
@@ -122,11 +105,6 @@ const backpackWeightItems = computed<WeightBarChartItem[]>(() => [
           ]
         : []),
 ]);
-
-// worn gears
-const wornGearsWeight = computed(() =>
-    _sumBy(props.wornGears, (gear) => (+gear.weight || 0) * gear.quantity),
-);
 </script>
 
 <style lang="scss">

--- a/composables/use-trip-weight-data.ts
+++ b/composables/use-trip-weight-data.ts
@@ -1,0 +1,59 @@
+export const useTripWeightData = ({
+    gearsRef,
+    wornGearsRef,
+    consumablesRef,
+}: {
+    gearsRef: Ref<GearWithQuantity[]>;
+    wornGearsRef: Ref<GearWithQuantity[]>;
+    consumablesRef: Ref<Consumable[]>;
+}) => {
+    // consumables
+    const consumablesByCategory = computed(() =>
+        dataUtils.groupConsumablesByCategory(consumablesRef.value),
+    );
+    const consumableWeightByCategory = computed(() =>
+        _mapValues(consumablesByCategory.value, (consumables) =>
+            _sumBy(consumables, dataUtils.getConsumableWeight),
+        ),
+    );
+    const consumablesWeight = computed(() =>
+        _sumBy(consumablesRef.value, dataUtils.getConsumableWeight),
+    );
+
+    // gears
+    const gearsByCategory = computed(() =>
+        dataUtils.groupGearsByCategory(gearsRef.value),
+    );
+    const gearWeightByCategory = computed(() =>
+        _mapValues(gearsByCategory.value, (gears) =>
+            _sumBy(gears, (gear) => (+gear.weight || 0) * gear.quantity),
+        ),
+    );
+    const gearsWeight = computed(() =>
+        _sumBy(gearsRef.value, (gear) => (+gear.weight || 0) * gear.quantity),
+    );
+
+    // backpack weight
+    const backpackWeight = computed(
+        () => gearsWeight.value + consumablesWeight.value,
+    );
+
+    // worn gears
+    const wornGearsWeight = computed(() =>
+        _sumBy(
+            wornGearsRef.value,
+            (gear) => (+gear.weight || 0) * gear.quantity,
+        ),
+    );
+
+    return {
+        gearsByCategory,
+        gearWeightByCategory,
+        gearsWeight,
+        consumablesByCategory,
+        consumableWeightByCategory,
+        consumablesWeight,
+        backpackWeight,
+        wornGearsWeight,
+    };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "pinia": "^2.1.7",
                 "primeicons": "^7.0.0",
                 "primevue": "^3.52.0",
+                "squarify": "^1.1.0",
                 "ua-parser-js": "^2.0.3",
                 "uuid": "^9.0.1"
             },
@@ -15049,6 +15050,12 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
             "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
             "dev": true
+        },
+        "node_modules/squarify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/squarify/-/squarify-1.1.0.tgz",
+            "integrity": "sha512-0nD8UD4FPOfWHdaVYACbr1SmBF5XQeTbDcRfVs8NHVtueRC0OPo4DN/TJVjAJZ0fLwrgDhEI3XrhUicglD9npw==",
+            "license": "MIT"
         },
         "node_modules/ssri": {
             "version": "10.0.5",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "pinia": "^2.1.7",
         "primeicons": "^7.0.0",
         "primevue": "^3.52.0",
+        "squarify": "^1.1.0",
         "ua-parser-js": "^2.0.3",
         "uuid": "^9.0.1"
     },

--- a/pages/trip-share/[id].vue
+++ b/pages/trip-share/[id].vue
@@ -35,30 +35,41 @@
             </TripHeader>
         </template>
         <template #side>
-            <TripWeightInfo
-                :gears="gearsInTrip"
-                :wornGears="wornGearsInTrip"
-                :consumables="consumablesInTrip"
-            />
-            <NuxtLink
-                to="/"
-                class="block w-full mt-3"
-                @click="
-                    () =>
-                        analyticsUtils.log(
-                            constants.ANALYTICS_EVENTS.CLICK_CTA_BUTTON,
-                            { trip_id: tripShare?.id, page_name: 'trip-share' },
-                        )
-                "
-            >
-                <PrimeButton
-                    :label="$t('ACTION_CREATE_YOUR_GEAR_LIST')"
-                    icon="pi pi-arrow-right"
-                    icon-pos="right"
-                    class="w-full"
-                    rounded
+            <div class="flex flex-column gap-3">
+                <TripWeightTreeMap
+                    :gears="gearsInTrip"
+                    :wornGears="wornGearsInTrip"
+                    :consumables="consumablesInTrip"
+                    :ratio="16 / 9"
                 />
-            </NuxtLink>
+                <TripWeightInfo
+                    :gears="gearsInTrip"
+                    :wornGears="wornGearsInTrip"
+                    :consumables="consumablesInTrip"
+                />
+                <NuxtLink
+                    to="/"
+                    class="block w-full"
+                    @click="
+                        () =>
+                            analyticsUtils.log(
+                                constants.ANALYTICS_EVENTS.CLICK_CTA_BUTTON,
+                                {
+                                    trip_id: tripShare?.id,
+                                    page_name: 'trip-share',
+                                },
+                            )
+                    "
+                >
+                    <PrimeButton
+                        :label="$t('ACTION_CREATE_YOUR_GEAR_LIST')"
+                        icon="pi pi-arrow-right"
+                        icon-pos="right"
+                        class="w-full"
+                        rounded
+                    />
+                </NuxtLink>
+            </div>
         </template>
         <template #main>
             <!-- base gears -->

--- a/pages/trip/[id].vue
+++ b/pages/trip/[id].vue
@@ -58,11 +58,19 @@
             </TripHeader>
         </template>
         <template #side>
-            <TripWeightInfo
-                :gears="gearsInTrip"
-                :wornGears="wornGearsInTrip"
-                :consumables="consumablesInTrip"
-            />
+            <div class="flex flex-column gap-3">
+                <TripWeightTreeMap
+                    :gears="gearsInTrip"
+                    :wornGears="wornGearsInTrip"
+                    :consumables="consumablesInTrip"
+                    :ratio="16 / 9"
+                />
+                <TripWeightInfo
+                    :gears="gearsInTrip"
+                    :wornGears="wornGearsInTrip"
+                    :consumables="consumablesInTrip"
+                />
+            </div>
         </template>
         <template #main>
             <!-- base gears -->

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1,4 +1,5 @@
 import type { Timestamp } from '@firebase/firestore';
+import type { Input as SquarifyInput } from 'squarify';
 
 declare global {
     type UserMeta = {
@@ -158,12 +159,17 @@ declare global {
         weight: number;
         label: string;
     };
-    type WeightBarChartItem = {
-        weight: number;
+    type WeighCharttItem = {
         label: string;
+        weight: number;
         color: string;
+    };
+    type WeightBarChartItem = WeighCharttItem & {
         addBorder?: boolean;
         subItems?: WeightBarChartSubItem[];
+    };
+    type WeightTreeMapItem<T> = SquarifyInput<WeighCharttItem> & {
+        data?: T;
     };
 
     type BrandData = { name: string; originalName?: string };


### PR DESCRIPTION
This pull request introduces a new feature to display a visual representation of gear and consumable weight distribution using a tree map. It also refactors weight calculation logic into a reusable composable, improves modularity, and updates relevant components to integrate the new feature.

### New Feature: Weight Tree Map Visualization
* [`components/TripWeightTreeMap.vue`](diffhunk://#diff-a8baa2fc03238cc48d322748e265b4d713b343a8e11f27d05b715e38639cd5f7R1-R184): Added a new component to render a tree map visualization for gear and consumable weight distribution. This includes dynamic resizing, hover effects, and integration with gear photo and category data.
* [`components/WeightTreeMap.vue`](diffhunk://#diff-d575019841b0fbc312562ecb743ded65d605b3778b95edf0daa07c035291d0e9R1-R53): Created a reusable tree map component powered by the `squarify` library for rendering hierarchical weight data.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R44): Added the `squarify` library as a dependency to enable tree map calculations.

### Refactoring: Weight Calculation Logic
* [`composables/use-trip-weight-data.ts`](diffhunk://#diff-15d657ea62c164049453a8425175cbdf0d5f2e8ef0b179ffd38582eb08498533R1-R59): Introduced a new composable `useTripWeightData` to centralize and simplify weight calculation logic for gears, worn gears, and consumables.
* [`components/trip/TripWeightInfo.vue`](diffhunk://#diff-767f8a566feaf152f4810f0d6eeea2a958f90ddba782b20e3022ddc9690cb4c7R65-L77): Refactored to use the new `useTripWeightData` composable, removing redundant computed properties and improving code clarity. [[1]](diffhunk://#diff-767f8a566feaf152f4810f0d6eeea2a958f90ddba782b20e3022ddc9690cb4c7R65-L77) [[2]](diffhunk://#diff-767f8a566feaf152f4810f0d6eeea2a958f90ddba782b20e3022ddc9690cb4c7L86-L106) [[3]](diffhunk://#diff-767f8a566feaf152f4810f0d6eeea2a958f90ddba782b20e3022ddc9690cb4c7L125-L129)

### Integration: Tree Map in Trip Pages
* `pages/trip-share/[id].vue`: Integrated the `TripWeightTreeMap` component into the trip share page, alongside existing weight info. ([pages/trip-share/[id].vueR38-R60](diffhunk://#diff-6bf33c97a426ea0cacf81e5ebcbbc57ac2a57145ce3afd2bcf682bb98ffaac3dR38-R60), [pages/trip-share/[id].vueR72](diffhunk://#diff-6bf33c97a426ea0cacf81e5ebcbbc57ac2a57145ce3afd2bcf682bb98ffaac3dR72))
* `pages/trip/[id].vue`: Integrated the `TripWeightTreeMap` component into the trip details page. ([pages/trip/[id].vueR61-R73](diffhunk://#diff-3e8013de2061b0be7f548068c4882c5f6cf595749841f37b7d52b72ea898bd01R61-R73))