### PR TITLE
doc: add contributing guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,104 @@ Hiking can be an exhilarating adventure, but carrying a heavy pack can quickly t
 Everygram is more than just an app; it's a community of hikers who value the art and science of lightweight packing. Join us, and let’s make every gram count together.
 
 Start your journey with Everygram today and experience the difference that meticulous weight management can make in your hiking adventures.
+
+## Contributing
+
+### Discord Chat Room
+
+[Join our Discord server](https://discord.gg/2tugC7QP) to connect with other Everygram developers and get support from the community.
+
+### Frontend
+
+-   The frontend of Everygram is built using Nuxt + Vue.js
+
+### Backend
+
+-   The backend is using Firebase for authentication, Firestore data storage, and Cloud Functions for serverless logic.
+
+## How to Run the Project in Your Local
+
+To safely develop new features and avoid breaking production, you should set up your own Firebase project and local environment. Follow these steps:
+
+1. **Clone the Repository**
+
+    ```bash
+    git clone https://github.com/LeeBoYin/everygram-nuxt.git
+    cd everygram-nuxt
+    ```
+
+2. **Install Dependencies**
+
+    Install the required dependencies for frontend:
+
+    ```bash
+    npm install
+    ```
+
+    Install the required dependencies for backend:
+
+    ```bash
+    cd functions
+    npm install
+    ```
+
+3. **Setup Firebase Project**
+
+    - Go to the [Firebase Console](https://console.firebase.google.com/).
+    - Create a new project (or use an existing one).
+    - Register Web app in the Firebase Console.
+    - Enable Authentication (Google signin), Cloud Functions, Firestore and Storage.
+
+4. **Configure Environment Variables**
+
+    Create a `.env` file in the root directory. Add your Firebase environment variables as shown below:
+
+    ```env
+    NUXT_PUBLIC_FIREBASE_API_KEY=your-api-key
+    NUXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+    NUXT_PUBLIC_FIREBASE_DATABASE_URL=https://your-project.firebaseio.com
+    NUXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
+    NUXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+    NUXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
+    NUXT_PUBLIC_FIREBASE_APP_ID=your-app-id
+    NUXT_PUBLIC_FIREBASE_MEASUREMENT_ID=your-measurement-id
+    ```
+
+5. **Add Firebase Admin SDK Credentials**
+
+    Create your Firebase Admin SDK JSON file at:
+
+    ```
+    functions/src/everygram-firebase-adminsdk.json
+    ```
+
+    You can generate this file from your Firebase project settings under "Service accounts".
+
+6. **Deploy Rules and Functions to Firebase**
+
+    Sign in to your Firebase account:
+
+    ```bash
+    npm install -g firebase-tools
+    firebase login
+    ```
+
+    Publish rules for Firestore and Storage.
+
+    ```bash
+    npm run deploy-rules
+    ```
+
+    Deploy Cloud Functions to Firebase, run:
+
+    ```bash
+    npm run deploy-functions
+    ```
+
+7. **Launch the Nuxt Development Server**
+
+    ```bash
+    npm run dev
+    ```
+
+    The app will be available at [http://localhost:3000](http://localhost:3000).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "prepare": "husky",
         "prettier": "npx prettier . --write",
         "emulator": "firebase emulators:start",
-        "deploy-functions": "firebase deploy --only functions"
+        "deploy-functions": "firebase deploy --only functions",
+        "deploy-rules": "firebase deploy --only firestore:rules,storage"
     },
     "devDependencies": {
         "@nuxt/devtools": "latest",


### PR DESCRIPTION
This pull request adds comprehensive contribution guidelines and local development instructions to the `README.md`, and introduces a new deployment script for Firestore and Storage rules in `package.json`. These changes make it easier for new contributors to set up the project and deploy backend rules, improving the onboarding experience and streamlining development.

**Documentation improvements:**

* Added a new "Contributing" section to `README.md`, including information about the Discord chat room, tech stack overview, and detailed step-by-step instructions for running the project locally with Firebase setup and deployment.

**Developer tooling:**

* Added a new `deploy-rules` npm script to `package.json` for deploying Firestore and Storage rules to Firebase, making backend rule deployment more convenient for contributors.