### PR TITLE
doc: Add missing step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ To safely develop new features and avoid breaking production, you should set up 
     firebase login
     ```
 
+    Select your Firebase project (replace with your actual Project ID).
+
+    ```bash
+    firebase use your-project-id
+    ```
+
     Publish rules for Firestore and Storage.
 
     ```bash


### PR DESCRIPTION
When setting up Firebase for the first time, the default project is used if you don’t explicitly select one.
This causes an error when running npm run deploy-rules from the README :

```bash
Error: Request to https://serviceusage.googleapis.com/v1/projects/everygram/services/firebasestorage.googleapis.com had HTTP Error: 403, Permission denied to get service [firebasestorage.googleapis.com]
```

This PR updates the README to include the missing step.

